### PR TITLE
Remove explicit status OK write

### DIFF
--- a/cmd/koinos-jsonrpc/main.go
+++ b/cmd/koinos-jsonrpc/main.go
@@ -200,8 +200,6 @@ func main() {
 			return
 		}
 
-		w.WriteHeader(http.StatusOK)
-
 		log.Debug(string(response))
 	}
 


### PR DESCRIPTION
Resolves #38

## Brief description
The first call to `Write` implicitly sets the headers to `status.OK`. Removal of the explicit call should remove the warning.

## Checklist

- [x] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
```console
2022-07-08 16:05:19.255369 (jsonrpc.Koinos) [koinos-mq-golang@v0.0.0-20210424202816-d2bd4d1894d1/client.go:95] <info>: Connecting client to AMQP server amqp://guest:guest@localhost:5672/
2022-07-08 16:05:19.259021 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: koinos.contracts.resources
2022-07-08 16:05:19.259903 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: koinos.contracts.token
2022-07-08 16:05:19.259779 (jsonrpc.Koinos) [koinos-mq-golang@v0.0.0-20210424202816-d2bd4d1894d1/connection.go:85] <info>: Dialing AMQP server amqp://guest:guest@localhost:5672/
2022-07-08 16:05:19.259947 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: koinos
2022-07-08 16:05:19.259995 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: koinos.protocol
2022-07-08 16:05:19.260017 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: koinos.chain
2022-07-08 16:05:19.260037 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: koinos.rpc.chain
2022-07-08 16:05:19.260054 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: koinos.contracts.pow
2022-07-08 16:05:19.260073 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: koinos.rpc
2022-07-08 16:05:19.260093 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: google.protobuf
2022-07-08 16:05:19.260106 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: koinos.block_store
2022-07-08 16:05:19.260124 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: koinos.rpc.contract_meta_store
2022-07-08 16:05:19.260143 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: koinos.chain
2022-07-08 16:05:19.260193 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: koinos.contracts.pob
2022-07-08 16:05:19.260214 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: koinos.contract_meta_store
2022-07-08 16:05:19.260561 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: koinos.broadcast
2022-07-08 16:05:19.260615 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: koinos.chain
2022-07-08 16:05:19.260644 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: google.protobuf
2022-07-08 16:05:19.260674 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: koinos.transaction_store
2022-07-08 16:05:19.260700 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: koinos.chain
2022-07-08 16:05:19.260725 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: koinos.chain
2022-07-08 16:05:19.260757 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: koinos.chain
2022-07-08 16:05:19.260781 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: koinos.contracts.governance
2022-07-08 16:05:19.260805 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: koinos.rpc.mempool
2022-07-08 16:05:19.260832 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: koinos
2022-07-08 16:05:19.261471 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: koinos.rpc.block_store
2022-07-08 16:05:19.261506 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: koinos.chain
2022-07-08 16:05:19.261541 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: koinos.chain
2022-07-08 16:05:19.261574 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: koinos.rpc.p2p
2022-07-08 16:05:19.261590 (jsonrpc.Koinos) [internal/jsonrpc.go:355] <info>: Registered descriptor package: koinos.rpc.transaction_store
2022-07-08 16:05:19.261646 (jsonrpc.Koinos) [koinos-jsonrpc/main.go:213] <info>: Listening on :8080/
2022-07-08 16:05:19.261900 (jsonrpc.Koinos) [koinos-jsonrpc/main.go:216] <error>: listen tcp :8080: bind: address already in use
2022-07-08 16:05:19.280503 (jsonrpc.Koinos) [koinos-mq-golang@v0.0.0-20210424202816-d2bd4d1894d1/client.go:114] <info>: Client connected
```
