### PR TITLE
Correctly handle empty parameters

### DIFF
--- a/internal/jsonrpc.go
+++ b/internal/jsonrpc.go
@@ -170,9 +170,11 @@ func translateRequest(j *RPCRequest, service string, qualifiedService string, me
 	// Construct proper requst object ('get_pending_transactions' -> 'get_pending_transactions_request')
 	// Parse request to Message
 	msg := dynamicpb.NewMessage(desc)
-	err := koinosjson.Unmarshal(j.Params, msg)
-	if err != nil {
-		return nil, ErrInvalidParams
+	if len(j.Params) > 0 {
+		err := koinosjson.Unmarshal(j.Params, msg)
+		if err != nil {
+			return nil, ErrInvalidParams
+		}
 	}
 
 	fieldd := req.Descriptor().Fields().ByName(protoreflect.Name(method))


### PR DESCRIPTION
## Brief description

Handle parsing empty parameters

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration

Previously:

```
$ curl -d '{"jsonrpc":"2.0", "method":"chain.get_head_info", "id":0}' http://localhost:8080/ | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   185  100   128  100    57   5175   2304 --:--:-- --:--:-- --:--:-- 14230
{
  "jsonrpc": "2.0",
  "error": {
    "code": -32601,
    "message": "Unable to translate request",
    "data": "Parameters could not be parsed"
  },
  "id": 0
}
```

Now:

```
$ curl -d '{"jsonrpc":"2.0", "method":"chain.get_head_info", "id":0}' http://localhost:8081/ | jq 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   435  100   378  100    57  28879   4354 --:--:-- --:--:-- --:--:-- 87000
{
  "jsonrpc": "2.0",
  "result": {
    "head_topology": {
      "id": "0x1220f76cc294b5bf1ca7e744d9f2f5004f2e34a3a52c4a89415016b8b7a618ea1376",
      "height": "596825",
      "previous": "0x122086ed3550c3f952cec93719b90771dfd8d98682da2dfd37333c3a2c81bfe9f18e"
    },
    "last_irreversible_block": "596765",
    "head_state_merkle_root": "EiAs1_MniFhZF907a3O2TFqJoVshQiDGtP_7mOyq-zulgQ==",
    "head_block_time": "1663104626650"
  },
  "id": 0
}
```