### PR TITLE
#45: Add json mime type to responses

### DIFF
--- a/cmd/koinos-jsonrpc/main.go
+++ b/cmd/koinos-jsonrpc/main.go
@@ -291,6 +291,7 @@ func main() {
 			return
 		}
 
+		w.Header().Set("Content-Type", "application/json")
 		_, err = w.Write(response)
 		if err != nil {
 			log.Warnf("An error occurred while writing HTTP response: %v", err.Error())


### PR DESCRIPTION
Resolves #45

## Brief description
Add proper `application/json` mime type to http responses.

## Checklist

- [x] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
```
$ curl -v "http://localhost:8080" -H "Content-Type: application/json" -d '{ "id":1, "jsonrpc": "2.0", "method":"block_store.get_highest_block", "params":{} }'
*   Trying 127.0.0.1:8080...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
> POST / HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.68.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 83
>
* upload completely sent off: 83 out of 83 bytes
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Wed, 17 May 2023 17:48:11 GMT
< Content-Length: 229
<
* Connection #0 to host localhost left intact
{"jsonrpc":"2.0","result":{"topology":{"id":"0x1220418b0680e8f93cb0938846ebc0f2da82f179a7b58bb97212cedde50d2be31100","height":"5355020","previous":"0x1220741df79335120d447f63c455628c4a256286b18797d4611bdda464f74c99e562"}},"id":1}
```
